### PR TITLE
fix(adapters): preserve DataFrame in SkforecastAdapter.predict (#18)

### DIFF
--- a/src/xeries/_version.py
+++ b/src/xeries/_version.py
@@ -1,3 +1,3 @@
 """Version information for xeries."""
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/src/xeries/adapters/skforecast.py
+++ b/src/xeries/adapters/skforecast.py
@@ -176,6 +176,13 @@ class SkforecastAdapter(BaseAdapter):
     def predict(self, X: pd.DataFrame) -> NDArray[Any]:
         """Make predictions using the underlying estimator.
 
+        The input ``X`` is forwarded to the underlying estimator unchanged when it
+        is a :class:`pandas.DataFrame` so that estimators which were fitted with
+        feature names (e.g. ``LGBMRegressor``, modern sklearn ``check_feature_names``
+        machinery) can match their training schema and avoid the
+        ``"X does not have valid feature names, but ... was fitted with feature names"``
+        warning. Non-DataFrame inputs are passed through untouched.
+
         Args:
             X: Input features DataFrame (same structure as training X).
 
@@ -185,8 +192,7 @@ class SkforecastAdapter(BaseAdapter):
         model = self._fitted_estimator
         if model is None:
             raise ValueError("No fitted estimator found on forecaster")
-        X_values = X.to_numpy() if isinstance(X, pd.DataFrame) else X
-        return np.asarray(model.predict(X_values))
+        return np.asarray(model.predict(X))
 
     def get_feature_names(self) -> list[str]:
         """Get predictor column names (lags, window features, etc.)."""

--- a/tests/unit/test_skforecast_adapter.py
+++ b/tests/unit/test_skforecast_adapter.py
@@ -1,0 +1,101 @@
+"""Unit tests for ``SkforecastAdapter`` that do not require ``skforecast``.
+
+The integration suite under ``tests/integration/test_skforecast.py`` exercises
+the adapter end-to-end against a real ``ForecasterRecursiveMultiSeries``. This
+file holds focused unit tests where we can mock the forecaster, so that
+regressions on adapter-level invariants are caught even on environments where
+``skforecast`` is not installed.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from xeries.adapters.skforecast import SkforecastAdapter
+
+
+class _RecordingEstimator:
+    """Stub estimator that records the input to :meth:`predict`."""
+
+    def __init__(self) -> None:
+        self.last_X: Any = None
+
+    def predict(self, X: Any) -> np.ndarray:
+        self.last_X = X
+        n = len(X) if hasattr(X, "__len__") else 1
+        return np.zeros(n)
+
+
+class _StubForecaster:
+    """Minimal stand-in for ``ForecasterRecursiveMultiSeries``.
+
+    Exposes the surface that
+    :meth:`SkforecastAdapter._validate_forecaster` checks for
+    (``estimator``, ``is_fitted``, ``create_train_X_y``) without importing
+    ``skforecast``.
+    """
+
+    def __init__(self, estimator: _RecordingEstimator) -> None:
+        self.estimator = estimator
+        self.is_fitted = True
+
+    def create_train_X_y(self, *args: Any, **kwargs: Any) -> tuple[pd.DataFrame, pd.Series]:
+        raise NotImplementedError("Not exercised by predict-path tests.")
+
+
+class TestSkforecastAdapterPredict:
+    """Regression tests for #18: ``predict`` must preserve DataFrame column names.
+
+    Sklearn / LightGBM emit ``"X does not have valid feature names, but ... was
+    fitted with feature names"`` when a model fitted on a DataFrame is later
+    called with a bare numpy array. Before #18, ``SkforecastAdapter.predict``
+    eagerly converted any DataFrame input via ``X.to_numpy()`` and triggered
+    that warning every time the adapter was used inside permutation /
+    per-series importance loops.
+    """
+
+    def test_dataframe_passes_through_with_columns(self) -> None:
+        """A DataFrame input reaches the estimator with column names intact."""
+        estimator = _RecordingEstimator()
+        adapter = SkforecastAdapter(_StubForecaster(estimator))
+
+        X = pd.DataFrame(
+            {
+                "lag_1": [1.0, 2.0, 3.0],
+                "lag_2": [4.0, 5.0, 6.0],
+                "promo": [0, 1, 0],
+            }
+        )
+        adapter.predict(X)
+
+        assert isinstance(estimator.last_X, pd.DataFrame), (
+            "Bug #18 regressed: SkforecastAdapter.predict() converted DataFrame "
+            f"to {type(estimator.last_X).__name__}, stripping the feature names "
+            "that LightGBM / sklearn rely on."
+        )
+        assert list(estimator.last_X.columns) == ["lag_1", "lag_2", "promo"]
+
+    def test_numpy_array_passes_through_unchanged(self) -> None:
+        """Non-DataFrame inputs (raw arrays) are still passed through untouched."""
+        estimator = _RecordingEstimator()
+        adapter = SkforecastAdapter(_StubForecaster(estimator))
+
+        X = np.array([[1.0, 2.0], [3.0, 4.0]])
+        adapter.predict(X)
+
+        assert isinstance(estimator.last_X, np.ndarray)
+        assert estimator.last_X.shape == (2, 2)
+
+    def test_predict_returns_numpy_array(self) -> None:
+        """``predict`` always wraps the underlying output in ``np.asarray``."""
+        estimator = _RecordingEstimator()
+        adapter = SkforecastAdapter(_StubForecaster(estimator))
+
+        X = pd.DataFrame({"lag_1": [1.0, 2.0]})
+        out = adapter.predict(X)
+
+        assert isinstance(out, np.ndarray)
+        assert out.shape == (2,)


### PR DESCRIPTION
Closes #18.

## Summary

[`SkforecastAdapter.predict`](https://github.com/xeries-labs/xeries/blob/main/src/xeries/adapters/skforecast.py) eagerly converted every `DataFrame` input via `X.to_numpy()` before forwarding it to the underlying estimator. That stripped the column names that sklearn / LightGBM use for runtime schema validation, so every call from inside `ConditionalPermutationImportance.explain` / `explain_per_series` produced:

```
UserWarning: X does not have valid feature names, but LGBMRegressor was fitted with feature names
```

One warning per feature × `n_repeats` × series — in practice hundreds of warnings per `explain_per_series` call.

### Fix

Forward `X` to the estimator unchanged. Non-DataFrame inputs (raw `numpy` arrays) keep working as before because they were already passed through. The patch matches what [`SklearnAdapter.predict`](https://github.com/xeries-labs/xeries/blob/main/src/xeries/adapters/sklearn.py) already did, so the two adapters are now consistent.

```diff
     def predict(self, X: pd.DataFrame) -> NDArray[Any]:
         model = self._fitted_estimator
         if model is None:
             raise ValueError("No fitted estimator found on forecaster")
-        X_values = X.to_numpy() if isinstance(X, pd.DataFrame) else X
-        return np.asarray(model.predict(X_values))
+        return np.asarray(model.predict(X))
```

## Tests

Added `tests/unit/test_skforecast_adapter.py` with three regression tests that mock the forecaster, so the adapter contract is verifiable on environments that don't have `skforecast` installed:

- `test_dataframe_passes_through_with_columns` — the exact regression for #18: a DataFrame input reaches the estimator with column names intact.
- `test_numpy_array_passes_through_unchanged` — raw arrays still flow through untouched.
- `test_predict_returns_numpy_array` — `np.asarray` wrap on the return is preserved.

```
$ uv run pytest tests/unit/test_skforecast_adapter.py -v --no-cov
============================= test session starts =============================
collected 3 items

tests/unit/test_skforecast_adapter.py::TestSkforecastAdapterPredict::test_dataframe_passes_through_with_columns PASSED [ 33%]
tests/unit/test_skforecast_adapter.py::TestSkforecastAdapterPredict::test_numpy_array_passes_through_unchanged    PASSED [ 66%]
tests/unit/test_skforecast_adapter.py::TestSkforecastAdapterPredict::test_predict_returns_numpy_array              PASSED [100%]

============================== 3 passed in 0.37s ==============================
```

`uv run ruff check` and `uv run ty check src` both pass on the touched files.

## Release

This PR also bumps `src/xeries/_version.py` from `0.2.0` to `0.2.1` so the patch release is ready to ride this merge. The release pipeline ([`.github/workflows/release.yml`](https://github.com/xeries-labs/xeries/blob/main/.github/workflows/release.yml)) is triggered by pushing a `v0.2.1` tag on the merged `main` HEAD; it validates that the tag matches `_version.py`, builds the wheel + sdist, publishes to PyPI via trusted publishing, and creates the GitHub release with auto-generated notes.

### Tagging procedure (post-merge)

```bash
git checkout main
git pull origin main
git tag -a v0.2.1 -m "fix(adapters): preserve DataFrame in SkforecastAdapter.predict"
git push origin v0.2.1
```

## Test plan

- [x] Patch `SkforecastAdapter.predict`
- [x] Add unit-level regression tests under `tests/unit/test_skforecast_adapter.py`
- [x] `uv run ruff check src/xeries/adapters/skforecast.py tests/unit/test_skforecast_adapter.py`
- [x] `uv run ty check src/xeries/adapters/skforecast.py`
- [x] `uv run pytest tests/unit/test_skforecast_adapter.py -v --no-cov` → 3 passed
- [x] Bump `src/xeries/_version.py` to `0.2.1`
- [x] CI green on this PR
- [ ] Squash-merge to `main`
- [ ] Push `v0.2.1` tag → release pipeline auto-publishes to PyPI